### PR TITLE
71-separated login and sign up modals

### DIFF
--- a/FrontEnd/src/App.js
+++ b/FrontEnd/src/App.js
@@ -6,8 +6,6 @@ import Home from "./pages/Home";
 import Programs from "./pages/LoggedIn/Programs";
 import Progress from "./pages/LoggedIn/Progress";
 import LogWorkout from "./pages/LoggedIn/LogWorkout";
-import Product from "./pages/LoggedOut/Product";
-import Contact from "./pages/LoggedOut/Contact";
 import ProgramView from "./components/Programs/ProgramView/ProgramView";
 import { programLoader } from "./loaders/ProgramLoader";
 

--- a/FrontEnd/src/components/Auth/LoginModal.js
+++ b/FrontEnd/src/components/Auth/LoginModal.js
@@ -6,16 +6,11 @@ import AuthContext from "../../context/auth-context";
 const LoginModal = () => {
   const modalRef = useRef(null);
   const ctx = useContext(AuthContext);
-  const [login, setLogin] = useState(true);
-
-  const loginHandler = () => {
-    setLogin((prevLogin) => !prevLogin);
-  };
 
   useEffect(() => {
     const clickOutsideHandler = (event) => {
       if (modalRef.current && !modalRef.current.contains(event.target)) {
-        ctx.setLoginModal(false);
+        ctx.setLoginModal({type: "close"});
       }
     };
     document.addEventListener("mousedown", clickOutsideHandler);
@@ -24,15 +19,23 @@ const LoginModal = () => {
     };
   }, [modalRef]);
 
+  const modalSwitch = () => {
+    if (ctx.loginModal.isLogin) {
+      ctx.setLoginModal({type: "signup"})
+    } else {
+      ctx.setLoginModal({type: "login"})
+    }
+  }
+
   return (
     <div
       ref={modalRef}
       className="fixed top-[50%] left-[50%] transform translate-x-[-50%] translate-y-[-50%] z-10 bg-white w-[60%] min-w-[500px] max-w-[700px] flex flex-row shadow-md"
     >
-      {login ? (
-        <Login switch={loginHandler} />
+      {ctx.loginModal.isLogin ? (
+        <Login switch={modalSwitch} />
       ) : (
-        <SignUp switch={loginHandler} />
+        <SignUp switch={modalSwitch} />
       )}
     </div>
   );

--- a/FrontEnd/src/components/Auth/SignUp.js
+++ b/FrontEnd/src/components/Auth/SignUp.js
@@ -44,7 +44,7 @@ const SignUp = (props) => {
         })
         .then((data) => {
           if (data.success) {
-            ctx.setLoginModal(false);
+            ctx.setLoginModal({type: "close"});
             ctx.setRedirectModal(true);
           } else {
             setEmailError(data.email);

--- a/FrontEnd/src/components/Auth/SignUpRedirect.js
+++ b/FrontEnd/src/components/Auth/SignUpRedirect.js
@@ -20,7 +20,7 @@ const SignUpRedirect = () => {
 
   const redirectHandler = () => {
     ctx.setRedirectModal(false);
-    ctx.setLoginModal(true);
+    ctx.setLoginModal({type: "login"});
   };
 
   return (

--- a/FrontEnd/src/components/Programs/ProgramShareModal/ProgramShareModal.js
+++ b/FrontEnd/src/components/Programs/ProgramShareModal/ProgramShareModal.js
@@ -69,7 +69,7 @@ const ProgramShareModel = (props) => {
           Cookies.remove("accessToken");
           Cookies.remove("refreshToken");
           window.location.reload();
-          ctx.setLoginModal(true);
+          ctx.setLoginModal({type: "login"});
           ctx.setStatus("Session timed out: You have been logged out");
         } else {
           navigate("/error", {
@@ -120,7 +120,7 @@ const ProgramShareModel = (props) => {
           Cookies.remove("accessToken");
           Cookies.remove("refreshToken");
           window.location.reload();
-          ctx.setLoginModal(true);
+          ctx.setLoginModal({type: "login"});
           ctx.setStatus("Session timed out: You have been logged out");
         } else {
           navigate("/error", {
@@ -180,7 +180,7 @@ const ProgramShareModel = (props) => {
           Cookies.remove("accessToken");
           Cookies.remove("refreshToken");
           window.location.reload();
-          ctx.setLoginModal(true);
+          ctx.setLoginModal({type: "login"});
           ctx.setStatus("Session timed out: You have been logged out");
         } else {
           navigate("/error", {

--- a/FrontEnd/src/components/Programs/ProgramView/ProgramView.js
+++ b/FrontEnd/src/components/Programs/ProgramView/ProgramView.js
@@ -186,7 +186,7 @@ const ProgramView = () => {
             Cookies.remove("accessToken");
             Cookies.remove("refreshToken");
             window.location.reload();
-            ctx.setLoginModal(true);
+            ctx.setLoginModal({type: "login"});
             ctx.setStatus("Session timed out: You have been logged out");
           } else {
             navigate("/error", {
@@ -290,7 +290,7 @@ const ProgramView = () => {
           Cookies.remove("accessToken");
           Cookies.remove("refreshToken");
           window.location.reload();
-          ctx.setLoginModal(true);
+          ctx.setLoginModal({type: "login"});
           ctx.setStatus("Session timed out: You have been logged out");
         } else {
           navigate("/error", {

--- a/FrontEnd/src/components/TopBar/AccountOptions.js
+++ b/FrontEnd/src/components/TopBar/AccountOptions.js
@@ -40,7 +40,7 @@ const AccountOptions = () => {
           Cookies.remove("accessToken");
           Cookies.remove("refreshToken");
           window.location.reload();
-          ctx.setLoginModal(true);
+          ctx.setLoginModal({type: "login"});
           ctx.setStatus("Session timed out: You have been logged out");
         } else {
           navigate("/error", {

--- a/FrontEnd/src/components/TopBar/TopBar.js
+++ b/FrontEnd/src/components/TopBar/TopBar.js
@@ -75,7 +75,7 @@ const TopBar = (props) => {
           <div
             className="flex items-center h-full self-center py-4 px-4 cursor-pointer hover:bg-slate-50"
             onClick={() => {
-              ctx.setLoginModal(true);
+              ctx.setLoginModal({type: "login"});
             }}
           >
             <p>Log In</p>

--- a/FrontEnd/src/context/auth-context.js
+++ b/FrontEnd/src/context/auth-context.js
@@ -1,9 +1,34 @@
-import { createContext, useState } from "react";
+import { createContext, useState, useReducer } from "react";
 
 const AuthContext = createContext();
 
+const loginModalReducer = (state, action) => {
+  switch (action.type) {
+    case "login":
+      return {
+        isOpen: true,
+        isLogin: true
+      }
+    case "signup":
+      return {
+        isOpen: true,
+        isLogin: false
+      }
+    case "close":
+      return {
+        ...state,
+        isOpen: false
+      }
+    default:
+      return state
+  }
+}
+
 export const AuthContextProvider = (props) => {
-  const [loginModal, setLoginModal] = useState(false);
+  const [loginModal, setLoginModal] = useReducer(loginModalReducer, {
+    isOpen: false,
+    isLogin: true
+  })
   const [redirectModal, setRedirectModal] = useState(false);
   const [status, setStatus] = useState("");
 

--- a/FrontEnd/src/pages/LoggedIn/Programs.js
+++ b/FrontEnd/src/pages/LoggedIn/Programs.js
@@ -41,7 +41,7 @@ const Programs = () => {
           Cookies.remove("accessToken");
           Cookies.remove("refreshToken");
           window.location.reload();
-          ctx.setLoginModal(true);
+          ctx.setLoginModal({type: "login"});
           ctx.setStatus("Session timed out: You have been logged out");
         } else {
           navigate("/error", {
@@ -82,7 +82,7 @@ const Programs = () => {
           Cookies.remove("accessToken");
           Cookies.remove("refreshToken");
           window.location.reload();
-          ctx.setLoginModal(true);
+          ctx.setLoginModal({type: "login"});
           ctx.setStatus("Session timed out: You have been logged out");
         } else {
           navigate("/error", {

--- a/FrontEnd/src/pages/LoggedOut/Landing.js
+++ b/FrontEnd/src/pages/LoggedOut/Landing.js
@@ -15,7 +15,7 @@ const Landing = () => {
         </p>
         <button
           onClick={() => {
-            ctx.setLoginModal(true);
+            ctx.setLoginModal({type: "signup"});
           }}
           className="text-white text-xl w-[300px] font-light bg-slate-700 px-3 py-2 rounded-full border border-slate-700 hover:text-slate-700 hover:bg-white"
         >

--- a/FrontEnd/src/pages/Root.js
+++ b/FrontEnd/src/pages/Root.js
@@ -8,40 +8,21 @@ import StatusBanner from "../components/StatusBanner";
 
 const Root = () => {
   const ctx = useContext(AuthContext);
-  const [loginModal, setLoginModal] = useState(ctx.loginModal);
-  const [redirectModal, setRedirectModal] = useState(ctx.redirectModal);
-  const [status, setStatus] = useState(ctx.status);
-
-  useEffect(() => {
-    setLoginModal(ctx.loginModal);
-  }, [ctx.loginModal]);
-
-  useEffect(() => {
-    setRedirectModal(ctx.redirectModal);
-  }, [ctx.redirectModal]);
-
-  useEffect(() => {
-    setStatus(ctx.status);
-  }, [ctx.status]);
-
-  const statusCloseHandler = () => {
-    ctx.setStatus("");
-  };
 
   return (
     <div className="h-screen">
       <TopBar />
-      {status && (
-        <StatusBanner msg={status} closeHandler={statusCloseHandler} />
+      {ctx.status && (
+        <StatusBanner msg={ctx.status} closeHandler={() => {ctx.setStatus("")}}/>
       )}
       <div className="pt-16">
         <Outlet />
-        {loginModal && <LoginModal />}
-        {loginModal && (
+        {ctx.loginModal.isOpen && <LoginModal />}
+        {ctx.loginModal.isOpen && (
           <div className="fixed top-0 left-0 w-full h-full z-[1] pointer-events-auto bg-black opacity-[15%]" />
         )}
-        {redirectModal && <SignUpRedirect />}
-        {redirectModal && (
+        {ctx.redirectModal && <SignUpRedirect />}
+        {ctx.redirectModal && (
           <div className="fixed top-0 left-0 w-full h-full z-[1] pointer-events-auto bg-black opacity-[15%]" />
         )}
       </div>


### PR DESCRIPTION
fix #71 
Signup and login page are both rendered in `LoginModal.js`. The `login` state in `LoginModal.js` determined whether login or signup page was rendered. By default it was always login.
I took the `login` state and put it in `AuthContext` so that we can specify whether login or signup is the default view rendered when the login modal pops up